### PR TITLE
[#2] refactor(setting): 상품 도메인 패키지 추가

### DIFF
--- a/src/main/java/com/sparta/shoppingmallmono/product/entity/Brand.java
+++ b/src/main/java/com/sparta/shoppingmallmono/product/entity/Brand.java
@@ -1,0 +1,24 @@
+package com.sparta.shoppingmallmono.product.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Brand {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private String name;
+}

--- a/src/main/java/com/sparta/shoppingmallmono/product/entity/Product.java
+++ b/src/main/java/com/sparta/shoppingmallmono/product/entity/Product.java
@@ -1,0 +1,33 @@
+package com.sparta.shoppingmallmono.product.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "products")
+public class Product {
+    @Id
+    @GeneratedValue
+    private UUID id;
+    private String title;
+    private int price;
+    private UUID brandId;
+    private String description;
+
+    @Column(precision = 5, scale = 2)
+    private double discountRate;
+
+    private String thumbnailImage;
+
+    @ElementCollection
+    @CollectionTable(name = "product_detail_images", joinColumns = @JoinColumn(name = "product_id"))
+    private List<String> detailImages;
+
+}

--- a/src/main/java/com/sparta/shoppingmallmono/product/entity/Stock.java
+++ b/src/main/java/com/sparta/shoppingmallmono/product/entity/Stock.java
@@ -1,0 +1,23 @@
+package com.sparta.shoppingmallmono.product.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Stock {
+    @Id
+    @GeneratedValue
+    private UUID id;
+    private int quantity;
+    private int exposedQuantity;
+}

--- a/src/main/java/com/sparta/shoppingmallmono/product/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/shoppingmallmono/product/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.shoppingmallmono.product.repository;
+
+import com.sparta.shoppingmallmono.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProductRepository extends JpaRepository< Product, UUID > {
+}

--- a/src/main/java/com/sparta/shoppingmallmono/product/service/ProductService.java
+++ b/src/main/java/com/sparta/shoppingmallmono/product/service/ProductService.java
@@ -1,0 +1,4 @@
+package com.sparta.shoppingmallmono.product.service;
+
+public interface ProductService {
+}

--- a/src/main/java/com/sparta/shoppingmallmono/product/service/dto/ProductDTO.java
+++ b/src/main/java/com/sparta/shoppingmallmono/product/service/dto/ProductDTO.java
@@ -1,0 +1,4 @@
+package com.sparta.shoppingmallmono.product.service.dto;
+
+public class ProductDTO {
+}

--- a/src/main/java/com/sparta/shoppingmallmono/product/service/impl/BasicProductService.java
+++ b/src/main/java/com/sparta/shoppingmallmono/product/service/impl/BasicProductService.java
@@ -1,0 +1,12 @@
+package com.sparta.shoppingmallmono.product.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BasicProductService {
+
+}


### PR DESCRIPTION

## 💡 작업동기
- 이커머스 사이트의 상품 관리 도메인

<br>

## 🔑 주요 구현/변경사항
- 상품 도메인 패키지 생성
- domain 패키지를 없애고 하위에 있던 repository와 entity를 밖으로 뺌
- 서비스의 인터페이스 
- 프레젠테이션단의 요청DTO와 서비스단의 DTO 분리 

<br>

### 🏞 스크린샷
![image](https://github.com/grey920/shopingmall-mono/assets/58028215/4815e890-597c-4102-92e1-8489033a5ea5)

<br>

## 🧨 발견 위험/장애
- 잘 안된 부분, 발생 이유와 어떻게 해결했는지

<br>

## 🔗 관련 이슈
- https://github.com/grey920/shopingmall-mono/issues/2#issue-2371188169 